### PR TITLE
Retry downloads, improve logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade --force --no-cache-dir pip
         pip install --force --no-cache-dir -r requirements.txt
-        pip install --force --no-cache-dir pytest
+        pip install --force --no-cache-dir pytest mock
 
     - name: PyTest
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       run: python -m pytest --junit-xml test-results/pytest.xml
 
     - name: Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1.0
+      uses: EnricoMi/publish-unit-test-result-action@master
       if: always()
       with:
         check_name: Unit Test Results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pybuildkite>=1.1.1
 PyGithub
+humanize

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -1,9 +1,15 @@
+import tempfile
 import unittest
+from typing import Set, Mapping
+
+import mock
+from requests import Response
 
 from download_artifacts import *
 
 
 class DownloadTest(unittest.TestCase):
+
     def test_make_path_safe(self):
         self.assertEqual('', make_path_safe(''))
         self.assertEqual('abc', make_path_safe('abc'))
@@ -30,3 +36,168 @@ class DownloadTest(unittest.TestCase):
                     id2='this is a very very very very very very very very very very very very long path '
                 )
             ))
+
+    @staticmethod
+    def error(code: int, message: str) -> HTTPError:
+        response = Response()
+        response.status_code = code
+        response.reason = message
+        return HTTPError('Exception', response=response)
+
+    http404 = error.__func__(404, 'Not Found')
+    http500 = error.__func__(500, 'Internal Server Error')
+
+    def create_buildkite_mock(self,
+                              artifact_ids: Set[str],
+                              errors: Mapping[str, List[HTTPError]]=None):
+        if errors is None:
+            errors = dict()
+
+        def download(org, pipeline, build_number, job_id, artifact_id):
+            if artifact_id in errors:
+                error = errors[artifact_id].pop()
+                if len(errors[artifact_id]) == 0:
+                    del errors[artifact_id]
+                raise error
+            elif artifact_id in artifact_ids:
+                return str(artifact_id).encode('utf8')
+            else:
+                raise self.http404
+
+        return mock.Mock(artifacts=mock.Mock(return_value=mock.Mock(download_artifact=mock.Mock(side_effect=download))))
+
+    org = 'org'
+    pipeline = 'pipeline'
+    build_number = 12345
+
+    def test_download_artifacts(self):
+        buildkite = self.create_buildkite_mock(
+            {'id1', 'id2', 'id3', 'id4', 'id5'},
+            {'id6': [self.http404]}
+        )
+        artifacts = [
+            {'id': 'id1', 'job_id': 'jid1', 'path': 'path1', 'state': 'unknown'},
+            {'id': 'id2', 'job_id': 'jid2', 'path': 'path2', 'state': 'new'},
+            {'id': 'id3', 'job_id': 'jid3', 'path': 'path3', 'state': 'error'},
+            {'id': 'id4', 'job_id': 'jid4', 'path': 'path4', 'state': 'finished'},
+            {'id': 'id5', 'job_id': 'jid5', 'path': 'path5', 'state': 'finished'},
+            {'id': 'id6', 'job_id': 'jid6', 'path': 'path6', 'state': 'finished'},
+        ]
+        job_names = {artifact['id']: f'file-{artifact["id"]}' for artifact in artifacts}
+
+        with tempfile.TemporaryDirectory() as path, \
+                mock.patch('download_artifacts.logger') as logger, \
+                mock.patch('download_artifacts.time.sleep') as time:
+
+            download_artifacts(buildkite, self.org, self.pipeline, self.build_number, artifacts, job_names, path)
+            for file in os.listdir(path):
+                print(file)
+
+            self.assertEqual([], time.mock_calls)
+
+            self.assertEqual(
+                [mock.call(self.org, self.pipeline, self.build_number, 'jid2', 'id2'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid4', 'id4'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid5', 'id5'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid6', 'id6')],
+                buildkite.artifacts.return_value.download_artifact.mock_calls
+            )
+
+            self.assertEqual(
+                [mock.call.info('Downloading 6 artifacts from build 12345'),
+                 mock.call.debug(f'writing 3 bytes to {path}/jid2/path2'),
+                 mock.call.debug(f'writing 3 bytes to {path}/jid4/path4'),
+                 mock.call.debug(f'writing 3 bytes to {path}/jid5/path5'),
+                 mock.call.debug(f'Downloading artifact id6 to {path}/jid6/path6 failed.', exc_info=self.http404)],
+                logger.mock_calls
+            )
+
+    def test_download_artifacts_retry(self):
+        buildkite = self.create_buildkite_mock(
+            {'id1', 'id2', 'id3'},
+            {'id2': [self.http500], 'id3': [self.http500, self.http500]}
+        )
+        artifacts = [
+            {'id': 'id1', 'job_id': 'jid1', 'path': 'path1', 'state': 'finished'},
+            {'id': 'id2', 'job_id': 'jid2', 'path': 'path2', 'state': 'finished'},
+            {'id': 'id3', 'job_id': 'jid3', 'path': 'path3', 'state': 'finished'},
+        ]
+        job_names = {artifact['id']: f'file-{artifact["id"]}' for artifact in artifacts}
+
+        with tempfile.TemporaryDirectory() as path, \
+                mock.patch('download_artifacts.logger') as logger, \
+                mock.patch('download_artifacts.time.sleep') as time:
+
+            download_artifacts(buildkite, self.org, self.pipeline, self.build_number, artifacts, job_names, path)
+            for file in os.listdir(path):
+                print(file)
+
+            self.assertEqual([mock.call(5), mock.call(20)], time.mock_calls)
+
+            self.assertEqual(
+                [mock.call(self.org, self.pipeline, self.build_number, 'jid1', 'id1'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid2', 'id2'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid3', 'id3'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid2', 'id2'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid3', 'id3'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid3', 'id3')],
+                buildkite.artifacts.return_value.download_artifact.mock_calls
+            )
+
+            self.assertEqual(
+                [mock.call.info('Downloading 3 artifacts from build 12345'),
+                 mock.call.debug(f'writing 3 bytes to {path}/jid1/path1'),
+                 mock.call.debug(f'Downloading artifact id2 to {path}/jid2/path2 failed.', exc_info=self.http500),
+                 mock.call.debug(f'Downloading artifact id3 to {path}/jid3/path3 failed.', exc_info=self.http500),
+                 mock.call.info('Download of 2 artifacts failed, retrying in 0:00:05.'),
+                 mock.call.debug(f'writing 3 bytes to {path}/jid2/path2'),
+                 mock.call.debug(f'Downloading artifact id3 to {path}/jid3/path3 failed.', exc_info=self.http500),
+                 mock.call.info('Download of 1 artifact failed, retrying in 0:00:20.'),
+                 mock.call.debug(f'writing 3 bytes to {path}/jid3/path3')],
+                logger.mock_calls
+            )
+
+    def test_download_artifacts_retry_exceeds(self):
+        buildkite = self.create_buildkite_mock(
+            {'id1'}, {'id1': [self.http500] * 5}
+        )
+        artifacts = [
+            {'id': 'id1', 'job_id': 'jid1', 'path': 'path1', 'state': 'finished'},
+        ]
+        job_names = {artifact['id']: f'file-{artifact["id"]}' for artifact in artifacts}
+
+        with tempfile.TemporaryDirectory() as path, \
+                mock.patch('download_artifacts.logger') as logger, \
+                mock.patch('download_artifacts.time.sleep') as time:
+
+            download_artifacts(buildkite, self.org, self.pipeline, self.build_number, artifacts, job_names, path)
+            for file in os.listdir(path):
+                print(file)
+
+            self.assertEqual(
+                [mock.call(5), mock.call(20), mock.call(80), mock.call(320)],
+                time.mock_calls
+            )
+
+            self.assertEqual(
+                [mock.call(self.org, self.pipeline, self.build_number, 'jid1', 'id1'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid1', 'id1'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid1', 'id1'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid1', 'id1'),
+                 mock.call(self.org, self.pipeline, self.build_number, 'jid1', 'id1')],
+                buildkite.artifacts.return_value.download_artifact.mock_calls
+            )
+
+            self.assertEqual(
+                [mock.call.info('Downloading 1 artifact from build 12345'),
+                 mock.call.debug(f'Downloading artifact id1 to {path}/jid1/path1 failed.', exc_info=self.http500),
+                 mock.call.info('Download of 1 artifact failed, retrying in 0:00:05.'),
+                 mock.call.debug(f'Downloading artifact id1 to {path}/jid1/path1 failed.', exc_info=self.http500),
+                 mock.call.info('Download of 1 artifact failed, retrying in 0:00:20.'),
+                 mock.call.debug(f'Downloading artifact id1 to {path}/jid1/path1 failed.', exc_info=self.http500),
+                 mock.call.info('Download of 1 artifact failed, retrying in 0:01:20.'),
+                 mock.call.debug(f'Downloading artifact id1 to {path}/jid1/path1 failed.', exc_info=self.http500),
+                mock.call.info('Download of 1 artifact failed, retrying in 0:05:20.'),
+                mock.call.debug(f'Downloading artifact id1 to {path}/jid1/path1 failed.', exc_info=self.http500)],
+                logger.mock_calls
+            )

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -119,8 +119,8 @@ class DownloadTest(unittest.TestCase):
                  '/jid4', '/jid4/path4',
                  '/jid5', '/jid5/path5',
                  '/jid6'],
-                [file[file.startswith(path) and len(path):]
-                 for file in glob(os.path.join(path, '**'), recursive=True)]
+                sorted([file[file.startswith(path) and len(path):]
+                        for file in glob(os.path.join(path, '**'), recursive=True)])
             )
 
             self.assertEqual([], time.mock_calls)
@@ -199,8 +199,8 @@ class DownloadTest(unittest.TestCase):
                  '/jid3', '/jid3/path3',
                  '/jid4', '/jid4/path4',
                  '/jid5'],
-                [file[file.startswith(path) and len(path):]
-                 for file in glob(os.path.join(path, '**'), recursive=True)]
+                sorted([file[file.startswith(path) and len(path):]
+                        for file in glob(os.path.join(path, '**'), recursive=True)])
             )
 
             self.assertEqual([mock.call(5), mock.call(20)], time.mock_calls)


### PR DESCRIPTION
Downloads that fail with 5xx error code are retried 4 times with exponential back-off. Artifacts in 'new' state are additionally retried in 4xx states. Progress is logged to info every 20 seconds. This logic is unit tested.

Fixes #9.