### PR TITLE
Add run attempt to artifact

### DIFF
--- a/test/test_download.py
+++ b/test/test_download.py
@@ -17,26 +17,29 @@ class DownloadTest(unittest.TestCase):
         self.assertEqual('abc-123-DEF', make_path_safe('abc 123  DEF'))
         self.assertEqual('some-paths', make_path_safe('some/paths/..'))
         self.assertEqual('some-characters', make_path_safe('some ⚡⚠✔✗ characters'))
-        self.assertEqual('this-is-a-very-very-very-very-very-very-very-very-very-very-very-very-long',
-                         make_path_safe('this is a very very very very very very very very very very very very long path'))
+        self.assertEqual('this-is-a-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long',
+                         make_path_safe('this is a very very very very very very very very very very very very very very very very very very very very very very very very very very very long path'))
 
     def test_make_dict_path_safe(self):
-        self.assertEqual(dict(), make_dict_path_safe(dict()))
-        self.assertEqual(dict(id='name'), make_dict_path_safe(dict(id='name')))
-        self.assertEqual(dict(id1='name1', id2='name2'), make_dict_path_safe(dict(id1='name1', id2='name2')))
-        self.assertEqual(dict(id1='name', id2='name_2', id3='name3'), make_dict_path_safe(dict(id1='name', id2='name', id3='name3')))
-        self.assertEqual(dict(id1='unsafe-name', id2='unsafe-name_2', id3='name3'), make_dict_path_safe(dict(id1='unsafe name', id2=' unsafe name', id3='name3')))
+        self.assertEqual(dict(), make_dict_path_safe(dict(), dict()))
+        self.assertEqual(dict(id='name'), make_dict_path_safe(dict(id='name'), dict()))
+        self.assertEqual(dict(id1='name1', id2='name2'), make_dict_path_safe(dict(id1='name1', id2='name2'), dict()))
+        self.assertEqual(dict(id1='name', id2='name_2', id3='name3'), make_dict_path_safe(dict(id1='name', id2='name', id3='name3'), dict()))
+        self.assertEqual(dict(id1='unsafe-name', id2='unsafe-name_2', id3='name3'), make_dict_path_safe(dict(id1='unsafe name', id2=' unsafe name', id3='name3'), dict()))
         self.assertEqual(
             dict(
-                id1='this-is-a-very-very-very-very-very-very-very-very-very-very-very-very-long',
-                id2='this-is-a-very-very-very-very-very-very-very-very-very-very-very-very-long_2'
+                id1='this-is-a-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long',
+                id2='this-is-a-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long_2'
             ),
             make_dict_path_safe(
                 dict(
-                    id1='this is a very very very very very very very very very very very very long path',
-                    id2='this is a very very very very very very very very very very very very long path '
-                )
+                    id1='this is a very very very very very very very very very very very very very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long path',
+                    id2='this is a very very very very very very very very very very very very very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long path '
+                ),
+                dict()
             ))
+
+        self.assertEqual(dict(id1='name-run-1', id2='name-run-2', id3='name3'), make_dict_path_safe(dict(id1='name', id2='name', id3='name3'), dict(id1=1, id2=2)))
 
     @staticmethod
     def error(code: int, message: str) -> HTTPError:


### PR DESCRIPTION
This adds the run attempt number to the artifact filename. Max filename length is increased to 150 characters. Beyond that, run number will be truncated as well.