### PR TITLE
Don't start downloading artifacts on 'failing' state

### DIFF
--- a/download_artifacts.py
+++ b/download_artifacts.py
@@ -288,7 +288,7 @@ def main(github_api_url: str, github_token: str, repo: str,
             if state != last_state:
                 logger.info('Build is in ''{}'' state.'.format(state))
                 last_state = state
-            if state not in ['running', 'scheduled', 'canceling']:
+            if state not in ['scheduled', 'running', 'canceling', 'failing']:
                 break
             if time.time() - last_log >= LOG_EVERY_SECONDS:
                 logger.debug('{} for build {} to finish.'.format(


### PR DESCRIPTION
Buildkite puts a build in `failing` state once a job failed so the entire build will fail. The build stays in that state until it terminates in `failed` state. We do not want to start to download artifacts until the build terminated, or we will not download all artifacts.